### PR TITLE
type-pointer fails when called with class

### DIFF
--- a/src/clojure/uncomplicate/clojure_cpp.clj
+++ b/src/clojure/uncomplicate/clojure_cpp.clj
@@ -1072,7 +1072,16 @@
     Byte/TYPE byte-pointer
     Character/TYPE char-pointer
     Boolean/TYPE bool-pointer
-    nil))
+    (cond
+      (= t Float/TYPE) float-pointer
+      (= t Double/TYPE) double-pointer
+      (= t Long/TYPE) long-pointer
+      (= t Integer/TYPE) int-pointer
+      (= t Short/TYPE) short-pointer
+      (= t Byte/TYPE) byte-pointer
+      (= t Character/TYPE) char-pointer
+      (= t Boolean/TYPE) bool-pointer)))
+
 
 (let [get-deallocator (doto (.getDeclaredMethod Pointer "deallocator" (make-array Class 0))
                         (.setAccessible true))


### PR DESCRIPTION
In neanderthal, `map-vector` calls this function with a java class such as Byte/TYPE, however the case function here effectively is comparing the class type passed in with (effectively) `(symbol "BYTE/Type")` and returns null, causing map-vector to fail in all cases for me.  

Adding the cond at the end, a pattern I copied from similar comparisons in neanderthal, fixes this so that `map-vector` works as intended.

 I left the symbol comparisons in because maybe there is actually a use case I'm not aware of in which that is desirable, but I have to imagine we would want to remove them.






